### PR TITLE
Reduces Snowflake, Adds EAT_THROUGH and Fixes Drinking Problem

### DIFF
--- a/code/__DEFINES/flags.dm
+++ b/code/__DEFINES/flags.dm
@@ -18,6 +18,7 @@
 
 #define BLOCK_GAS_SMOKE_EFFECT	8192	// blocks the effect that chemical clouds would have on a mob --glasses, mask and helmets ONLY!
 #define THICKMATERIAL 			8192	//prevents syringes, parapens and hypos if the external suit or helmet (if targeting head) has this flag. Example: space suits, biosuit, bombsuits, thick suits that cover your body. (NOTE: flag shared with BLOCK_GAS_SMOKE_EFFECT)
+#define EAT_THROUGH				16384	// Means you can eat through the clothing item, but it incurs a do_mob() in eating code in code/modules/mob/living/carbon/carbon.dm.
 
 //Reagent flags
 #define REAGENT_NOREACT			1

--- a/code/modules/clothing/masks/breath.dm
+++ b/code/modules/clothing/masks/breath.dm
@@ -43,8 +43,9 @@
 	actions_types = list()
 
 /obj/item/clothing/mask/breath/plasmaman
-	desc = "A breath mask designed specifically for operation with a Plasmaman suit and helmet."
+	desc = "A breath mask designed specifically for operation with a Plasmaman suit and helmet. It seems to offer an enhanced seal."
 	name = "plasmaman breath mask"
 	flags = AIRTIGHT|EAT_THROUGH
 	permeability_coefficient = 0.01
+	species_restricted = list("Plasmaman")
 	actions_types = list()

--- a/code/modules/clothing/masks/breath.dm
+++ b/code/modules/clothing/masks/breath.dm
@@ -37,6 +37,14 @@
 	name = "vox breath mask"
 	icon_state = "voxmask"
 	item_state = "voxmask"
+	flags = AIRTIGHT|EAT_THROUGH
 	permeability_coefficient = 0.01
 	species_restricted = list("Vox")
+	actions_types = list()
+
+/obj/item/clothing/mask/breath/plasmaman
+	desc = "A breath mask designed specifically for operation with a Plasmaman suit and helmet."
+	name = "plasmaman breath mask"
+	flags = AIRTIGHT|EAT_THROUGH
+	permeability_coefficient = 0.01
 	actions_types = list()

--- a/code/modules/clothing/spacesuits/plasmamen.dm
+++ b/code/modules/clothing/spacesuits/plasmamen.dm
@@ -69,7 +69,7 @@
 /obj/item/clothing/head/helmet/space/eva/plasmaman
 	name = "plasmaman helmet"
 	desc = "A special containment helmet designed to protect a plasmaman's volatile body from outside exposure and quickly extinguish it in emergencies."
-	flags = STOPSPRESSUREDMAGE
+	flags = STOPSPRESSUREDMAGE|EAT_THROUGH
 	icon = 'icons/obj/clothing/species/plasmaman/hats.dmi'
 	species_restricted = list("Plasmaman")
 	sprite_sheets = list(

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -995,11 +995,11 @@ var/list/ventcrawl_machinery = list(/obj/machinery/atmospherics/unary/vent_pump,
 	return 1
 
 /mob/living/carbon/proc/selfFeed(var/obj/item/weapon/reagent_containers/food/toEat, fullness, var/eating_through = 0)
-	if(eating_through && !do_mob(src, src, 20))
-		return 0
 	if(ispill(toEat))
 		to_chat(src, "<span class='notify'>You [toEat.apply_method] [toEat].</span>")
 	else
+		if(eating_through && !do_mob(src, src, 20))
+			return 0
 		if(toEat.junkiness && satiety < -150 && nutrition > NUTRITION_LEVEL_STARVING + 50 )
 			to_chat(src, "<span class='notice'>You don't feel like eating any more junk food at the moment.</span>")
 			return 0

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -2001,7 +2001,7 @@
 			to_chat(src, "<span class='notice'>You pour a bit of liquid from [toDrink] into your connection port.</span>")
 	else
 		to_chat(src, "<span class='notice'>You swallow a gulp of [toDrink].</span>")
-	return 1
+	return ..()
 
 /mob/living/carbon/human/can_track(mob/living/user)
 	if(wear_id)

--- a/code/modules/mob/living/carbon/human/species/plasmaman.dm
+++ b/code/modules/mob/living/carbon/human/species/plasmaman.dm
@@ -42,7 +42,7 @@
 	if(assigned_role != "Clown")
 		H.unEquip(H.wear_mask)
 
-	H.equip_or_collect(new /obj/item/clothing/mask/breath(H), slot_wear_mask)
+	H.equip_or_collect(new /obj/item/clothing/mask/breath/plasmaman(H), slot_wear_mask)
 	var/suit=/obj/item/clothing/suit/space/eva/plasmaman/assistant
 	var/helm=/obj/item/clothing/head/helmet/space/eva/plasmaman/assistant
 	var/tank_slot = slot_s_store


### PR DESCRIPTION
`EAT_THROUGH` is a flag that, when appended to a piece of headwear (helmet/mask), will incur a 2-second `do_mob()` when feeding/drinking.
However, this `do_mob()` is not applied when you force someone else to eat or drink, since that has its own (slightly longer) `do_mob()`.

The issue this fixes with drinking is that while `mob/living/carbon/human`s' `selfFeed` and `forceFed` procs called their parent (thus enacting the eat code in `code/modules/mob/living/carbon/carbon.dm`), `selfDrink` did not, despite the parent returning 1 and nothing else... Which had to be remedied in order to make drinking respect `code/modules/mob/living/carbon/carbon.dm` eatcode and thus incur the 2 second `do_mob` eating does (if you're wearing headwear that has the EAT_THROUGH) flag.

